### PR TITLE
feat: make output implementations thread-safe

### DIFF
--- a/core/output/interactive.go
+++ b/core/output/interactive.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 )
 
 const (
@@ -28,6 +29,7 @@ type interactiveShellOutput struct {
 	errOut    *spinner
 	verbosity int
 	status    string
+	lock      sync.Mutex
 }
 
 func (o *interactiveShellOutput) Info(msg string) {
@@ -67,12 +69,19 @@ func (o *interactiveShellOutput) ErrorWriter() io.Writer {
 
 func (o *interactiveShellOutput) StartOperation(status string) {
 	o.EndOperation(true)
+
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
 	o.status = status
 	o.errOut.SetSuffix(fmt.Sprintf(" %s ", o.status))
 	o.errOut.Start()
 }
 
 func (o *interactiveShellOutput) EndOperation(success bool) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
 	if o.status == "" {
 		return
 	}

--- a/core/output/non_interactive.go
+++ b/core/output/non_interactive.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -41,6 +42,7 @@ type nonInteractiveShellOutput struct {
 	verbosity     int
 	status        string
 	keysAndValues []interface{}
+	lock          sync.Mutex
 }
 
 func (o *nonInteractiveShellOutput) Info(msg string) {
@@ -71,11 +73,18 @@ func (o *nonInteractiveShellOutput) ErrorWriter() io.Writer {
 
 func (o *nonInteractiveShellOutput) StartOperation(status string) {
 	o.EndOperation(true)
+
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
 	o.status = status
 	o.Infof(" • %s...", o.status)
 }
 
 func (o *nonInteractiveShellOutput) EndOperation(success bool) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
 	if o.status == "" {
 		return
 	}


### PR DESCRIPTION
Before, `StartOperation()` and `EndOperation()` were not safe for concurrent use. That was fine for the current use in Diagnostics and Kommander-CLI, but might have caused head-aches in the future.