### PR TITLE
feat: Allow to store Output in context.Context

### DIFF
--- a/core/output/context.go
+++ b/core/output/context.go
@@ -1,0 +1,22 @@
+// Copyright 2022 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import "context"
+
+type key struct{}
+
+// WithContext allows to store an instance of Output in context.Context.
+func WithContext(ctx context.Context, o Output) context.Context {
+	return context.WithValue(ctx, key{}, o)
+}
+
+// Ctx restores Output from a given Context.
+func Ctx(ctx context.Context) Output {
+	if o, ok := ctx.Value(key{}).(Output); ok {
+		return o
+	}
+
+	return &noopOutput{}
+}

--- a/core/output/context_test.go
+++ b/core/output/context_test.go
@@ -1,0 +1,38 @@
+// Copyright 2022 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreAndRestoreOutoutInsideContext(t *testing.T) {
+	output := NewNonInteractiveShell(os.Stdout, os.Stdout, 10)
+
+	output.Info("hello")
+	ctx := context.Background()
+	ctx = WithContext(ctx, output)
+	restoredOutput := Ctx(ctx)
+	_, isRightType := restoredOutput.(*nonInteractiveShellOutput)
+	assert.True(t, isRightType, "restored Output is not of the expected type")
+	restoredOutput.Info("world")
+}
+
+func ExampleContext() {
+	ctx := context.Background()
+	ctx = WithContext(
+		ctx,
+		NewInteractiveShell(os.Stdout, os.Stdout, 10),
+	)
+
+	output := Ctx(ctx)
+	output.Info("hello world")
+
+	// Output:
+	// hello world
+}


### PR DESCRIPTION
We often pass context together with Output type, e.g.:
- https://github.com/mesosphere/kommander-cli/blob/406ee4c4f8fd676695087248b5b91423750a583a/pkg/git/gitea/portforward.go#L17
- https://github.com/mesosphere/kommander-cli/blob/4b423c03e5f65322e23ada8d2a3ee61355e27016/pkg/charts/upload.go#L24
- https://github.com/mesosphere/kommander-cli/blob/12c908f985b24576e7f15cf4fb2f146742caefb1/pkg/helm/helm.go#L74

I would like to allow to store `Output` in `Context` so we can only pass one parameter and worry about `Output` only when root `Context` is created.
