### PR TITLE
feat: rename "buildDate" to "commitDate"

### DIFF
--- a/core/cmd/version/version.go
+++ b/core/cmd/version/version.go
@@ -21,7 +21,7 @@ var (
 	gitVersion   = "v0.0.0-dev"
 	gitCommit    = ""
 	gitTreeState = ""
-	buildDate    = "1970-01-01T00:00:00Z"
+	commitDate   = "1970-01-01T00:00:00Z"
 )
 
 // Version is a struct for version information.
@@ -31,7 +31,7 @@ type Version struct {
 	GitVersion   string `json:"gitVersion"`
 	GitCommit    string `json:"gitCommit"`
 	GitTreeState string `json:"gitTreeState"`
-	BuildDate    string `json:"buildDate"`
+	CommitDate   string `json:"commitDate"`
 	GoVersion    string `json:"goVersion"`
 	Compiler     string `json:"compiler"`
 	Platform     string `json:"platform"`
@@ -45,7 +45,7 @@ func GetVersion() Version {
 		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
-		BuildDate:    buildDate,
+		CommitDate:   commitDate,
 		GoVersion:    runtime.Version(),
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),

--- a/core/cmd/version/version_test.go
+++ b/core/cmd/version/version_test.go
@@ -18,7 +18,7 @@ func TestVersionCommand(t *testing.T) {
 		Major:      "1",
 		Minor:      "2",
 		GitVersion: "v1.2",
-		BuildDate:  "2021-12-13 12:52:12 UTC",
+		CommitDate: "2021-12-13 12:52:12 UTC",
 		GoVersion:  "go1.17.5",
 		Compiler:   "gc",
 		Platform:   "linux/amd64",
@@ -28,7 +28,7 @@ func TestVersionCommand(t *testing.T) {
 		Major:      "2",
 		Minor:      "3",
 		GitVersion: "v2.3",
-		BuildDate:  "2021-12-14 12:52:12 UTC",
+		CommitDate: "2021-12-14 12:52:12 UTC",
 		GoVersion:  "go1.17.7",
 		Compiler:   "gcc-go",
 		Platform:   "linux/arm64",
@@ -50,7 +50,7 @@ func TestVersionCommand(t *testing.T) {
 		assertOutput(t, "long", versionGetter,
 			[]string{"--long"},
 			`version.Version{Major:"1", Minor:"2", GitVersion:"v1.2", GitCommit:"", GitTreeState:"", `+
-				`BuildDate:"2021-12-13 12:52:12 UTC", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}`+"\n",
+				`CommitDate:"2021-12-13 12:52:12 UTC", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}`+"\n",
 		)
 
 		assertOutput(t, "JSON", versionGetter,
@@ -90,9 +90,9 @@ func TestVersionCommand(t *testing.T) {
 		assertOutput(t, "long", versionGetter,
 			[]string{"--long"},
 			`A: version.Version{Major:"1", Minor:"2", GitVersion:"v1.2", GitCommit:"", GitTreeState:"", `+
-				`BuildDate:"2021-12-13 12:52:12 UTC", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}`+"\n"+
+				`CommitDate:"2021-12-13 12:52:12 UTC", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}`+"\n"+
 				`B: version.Version{Major:"2", Minor:"3", GitVersion:"v2.3", GitCommit:"", GitTreeState:"", `+
-				`BuildDate:"2021-12-14 12:52:12 UTC", GoVersion:"go1.17.7", Compiler:"gcc-go", Platform:"linux/arm64"}`+"\n",
+				`CommitDate:"2021-12-14 12:52:12 UTC", GoVersion:"go1.17.7", Compiler:"gcc-go", Platform:"linux/arm64"}`+"\n",
 		)
 
 		assertOutput(t, "JSON", versionGetter,
@@ -130,14 +130,14 @@ const jsonOutputSingle = `{
   "gitVersion": "v1.2",
   "gitCommit": "",
   "gitTreeState": "",
-  "buildDate": "2021-12-13 12:52:12 UTC",
+  "commitDate": "2021-12-13 12:52:12 UTC",
   "goVersion": "go1.17.5",
   "compiler": "gc",
   "platform": "linux/amd64"
 }
 `
 
-const yamlOutputSingle = `buildDate: 2021-12-13 12:52:12 UTC
+const yamlOutputSingle = `commitDate: 2021-12-13 12:52:12 UTC
 compiler: gc
 gitCommit: ""
 gitTreeState: ""
@@ -156,7 +156,7 @@ const jsonOutputMulti = `{
     "gitVersion": "v1.2",
     "gitCommit": "",
     "gitTreeState": "",
-    "buildDate": "2021-12-13 12:52:12 UTC",
+    "commitDate": "2021-12-13 12:52:12 UTC",
     "goVersion": "go1.17.5",
     "compiler": "gc",
     "platform": "linux/amd64"
@@ -167,7 +167,7 @@ const jsonOutputMulti = `{
     "gitVersion": "v2.3",
     "gitCommit": "",
     "gitTreeState": "",
-    "buildDate": "2021-12-14 12:52:12 UTC",
+    "commitDate": "2021-12-14 12:52:12 UTC",
     "goVersion": "go1.17.7",
     "compiler": "gcc-go",
     "platform": "linux/arm64"
@@ -176,7 +176,7 @@ const jsonOutputMulti = `{
 `
 
 const yamlOutputMulti = `A:
-  buildDate: 2021-12-13 12:52:12 UTC
+  commitDate: 2021-12-13 12:52:12 UTC
   compiler: gc
   gitCommit: ""
   gitTreeState: ""
@@ -186,7 +186,7 @@ const yamlOutputMulti = `A:
   minor: "2"
   platform: linux/amd64
 B:
-  buildDate: 2021-12-14 12:52:12 UTC
+  commitDate: 2021-12-14 12:52:12 UTC
   compiler: gcc-go
   gitCommit: ""
   gitTreeState: ""


### PR DESCRIPTION
The name "buildDate" might confuse users because it doesn't really
reflect the date that the binary was built but rather the date of the
last commit for both, Konvoy
(https://github.com/mesosphere/konvoy2/blob/47a2561aea15ea2912cb45e19\
abdc8cb94624ce0/.goreleaser.yml#L30) and Kommander
(https://github.com/mesosphere/kommander-cli/blob/ee76b1cfeccbb93deec\
0b1f5a9d4528cf1a122f1/.goreleaser.yml#L17).

Also, having the build date baked into the binary does seem to counter
our efforts to provide a reproducible build environment.

Discussion: https://mesosphere.slack.com/archives/C0152RGV2KU/p1647852794546139