### PR TITLE
fix: Clear gauge on spinner when ending operation

### DIFF
--- a/core/output/interactive.go
+++ b/core/output/interactive.go
@@ -137,6 +137,7 @@ func (o *interactiveShellOutput) EndOperationWithStatus(endStatus EndOperationSt
 	endStatus.Fprintln(o.errOut, status)
 	o.status = ""
 	o.gauge = nil
+	o.errOut.SetProgressGauge(nil)
 }
 
 func (o *interactiveShellOutput) Result(result string) {

--- a/core/output/interactive_test.go
+++ b/core/output/interactive_test.go
@@ -409,6 +409,14 @@ func TestInteractiveShellOutput(t *testing.T) {
 		tOutput.Error(nil, "another error")
 		tOutput.EndOperationWithStatus(output.Failure())
 
+		tOutput.StartOperationWithProgress(gauge)
+		gauge.Set(10)
+		tOutput.Info(gauge.String())
+		tOutput.EndOperationWithStatus(output.Success())
+
+		tOutput.StartOperation("without a gauge")
+		tOutput.EndOperationWithStatus(output.Success())
+
 		result := strings.TrimSuffix(errOut.String(), "\n")
 
 		outputLines := strings.Split(result, "\r")
@@ -425,6 +433,9 @@ func TestInteractiveShellOutput(t *testing.T) {
 			" " + termGreen + "✓" + termDefaultFg + " a message [==================================>10/10] (time elapsed 00s) ",
 			termClearLine + termRed + "another error" + termDefaultFg,
 			" " + termRed + "✗" + termDefaultFg + " a message [===>                                1/10] (time elapsed 00s) ",
+			termClearLine + " a message [==================================>10/10] (time elapsed 00s) ",
+			" " + termGreen + "✓" + termDefaultFg + " a message [==================================>10/10] (time elapsed 00s) ",
+			" " + termGreen + "✓" + termDefaultFg + " without a gauge",
 		}
 		actualFinalOutputLines := strings.Split(result, "\n")
 		assert.Len(actualFinalOutputLines, len(expectedFinalOutputLines))


### PR DESCRIPTION
Previously the gauge was output on the next operation as well:

```
 ✓ Pulling requested images [====================================>5/5] (time elapsed 10s)
 ✓ Archiving images to images.tar================================>5/5] (time elapsed 10s)
```

With this fix, the output is correct:

```
 ✓ Pulling requested images [====================================>5/5] (time elapsed 10s)
 ✓ Archiving images to images.tar
```